### PR TITLE
Use latest poetry installer

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ for env_file in $BUILDPACK_VARIABLES ; do
 done
 
 if [ -z "${POETRY_VERSION:-}" ] ; then
-    export POETRY_VERSION=1.1.5
+    export POETRY_VERSION=1.2.0
     log "No Poetry version specified in POETRY_VERSION config var. Defaulting to $POETRY_VERSION."
 else
     log "Using Poetry version from POETRY_VERSION config var: $POETRY_VERSION"
@@ -36,17 +36,13 @@ log "Generate requirements.txt with Poetry"
 
 log "Install Poetry"
 
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py \
+curl -sSL https://install.python-poetry.org \
     | sed -e 's/allowed_executables = \["python", "python3"\]/allowed_executables = ["python3"]/' \
     | python3 \
     | indent
 
-PATH_TO_POETRY_ENV="$HOME/.poetry/env"
-
-if [ -f "$PATH_TO_POETRY_ENV" ] ; then
-    # shellcheck source=/dev/null
-    . "$PATH_TO_POETRY_ENV"
-fi
+log "Adding poetry to the PATH"
+export PATH="/app/.local/bin:$PATH"
 
 REQUIREMENTS_FILE="requirements.txt"
 
@@ -63,7 +59,7 @@ fi
 
 # pip can't handle vcs & editable dependencies when requiring hashes (https://github.com/pypa/pip/issues/4995)
 # poetry exports local dependencies as editable by default (https://github.com/python-poetry/poetry/issues/897)
-poetry export -f "$REQUIREMENTS_FILE" "${EXPORT_PARAMETERS[@]}" > "$REQUIREMENTS_FILE.orig"
+poetry export -f "$REQUIREMENTS_FILE" "${EXPORT_PARAMETERS[@]}" -o "$REQUIREMENTS_FILE.orig"
 sed -e 's/^-e //' < "$REQUIREMENTS_FILE.orig" > "$REQUIREMENTS_FILE" && rm "$REQUIREMENTS_FILE.orig"
 
 RUNTIME_FILE="runtime.txt"

--- a/test/fixtures/compile-export_dev.stdout.txt
+++ b/test/fixtures/compile-export_dev.stdout.txt
@@ -1,9 +1,11 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.5.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
 -----> Enable exporting dev requirements to requirements.txt
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock
 -----> Write 3.8.3 into runtime.txt

--- a/test/fixtures/compile-export_dev.stdout.txt
+++ b/test/fixtures/compile-export_dev.stdout.txt
@@ -5,7 +5,7 @@
 -----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
 -----> Enable exporting dev requirements to requirements.txt
-       >>> mocked poetry call <<<
+>>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock
 -----> Write 3.8.3 into runtime.txt

--- a/test/fixtures/compile-force_poetry_version.stdout.txt
+++ b/test/fixtures/compile-force_poetry_version.stdout.txt
@@ -4,6 +4,6 @@
        >>> mocked curl call <<<
 -----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
-       >>> mocked poetry call <<<
+>>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Skip generation of runtime.txt file from poetry.lock

--- a/test/fixtures/compile-force_poetry_version.stdout.txt
+++ b/test/fixtures/compile-force_poetry_version.stdout.txt
@@ -2,6 +2,8 @@
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Skip generation of runtime.txt file from poetry.lock

--- a/test/fixtures/compile-force_python_version.stdout.txt
+++ b/test/fixtures/compile-force_python_version.stdout.txt
@@ -4,7 +4,7 @@
        >>> mocked curl call <<<
 -----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
-       >>> mocked poetry call <<<
+>>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Force Python version to 3.4.5, because PYTHON_RUNTIME_VERSION is set!
 -----> Write 3.4.5 into runtime.txt

--- a/test/fixtures/compile-force_python_version.stdout.txt
+++ b/test/fixtures/compile-force_python_version.stdout.txt
@@ -1,8 +1,10 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.5.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Force Python version to 3.4.5, because PYTHON_RUNTIME_VERSION is set!
 -----> Write 3.4.5 into runtime.txt

--- a/test/fixtures/compile-invalid_python_version.stdout.txt
+++ b/test/fixtures/compile-invalid_python_version.stdout.txt
@@ -4,6 +4,6 @@
        >>> mocked curl call <<<
 -----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
-       >>> mocked poetry call <<<
+>>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock

--- a/test/fixtures/compile-invalid_python_version.stdout.txt
+++ b/test/fixtures/compile-invalid_python_version.stdout.txt
@@ -1,7 +1,9 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.5.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock

--- a/test/fixtures/compile-no_vars_success.stdout.txt
+++ b/test/fixtures/compile-no_vars_success.stdout.txt
@@ -4,7 +4,7 @@
        >>> mocked curl call <<<
 -----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
-       >>> mocked poetry call <<<
+>>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock
 -----> Write 3.8.3 into runtime.txt

--- a/test/fixtures/compile-no_vars_success.stdout.txt
+++ b/test/fixtures/compile-no_vars_success.stdout.txt
@@ -1,8 +1,10 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.5.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock
 -----> Write 3.8.3 into runtime.txt

--- a/test/fixtures/compile-skip_runtime_error.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_error.stdout.txt
@@ -4,5 +4,5 @@
        >>> mocked curl call <<<
 -----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
-       >>> mocked poetry call <<<
+>>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-skip_runtime_error.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_error.stdout.txt
@@ -1,6 +1,8 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.5.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-skip_runtime_success.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_success.stdout.txt
@@ -1,7 +1,9 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.5.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Skip generation of runtime.txt file from poetry.lock

--- a/test/fixtures/compile-skip_runtime_success.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_success.stdout.txt
@@ -4,6 +4,6 @@
        >>> mocked curl call <<<
 -----> Adding poetry to the PATH
 -----> Export requirements.txt from Poetry
-       >>> mocked poetry call <<<
+>>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Skip generation of runtime.txt file from poetry.lock

--- a/test/utils
+++ b/test/utils
@@ -25,6 +25,8 @@ function run_test() {
     local command_name="$2"
     shift 2
 
+    touch "$INPUT_DIR"/requirements.txt.orig
+
     (
         bash ../bin/"$command_name" "$@"
     ) 1> "$OUTPUT_DIR/$command_name-$test_name.stdout.txt" 2> "$OUTPUT_DIR/$command_name-$test_name.stderr.txt"
@@ -58,7 +60,7 @@ function curl() {
 export -f curl
 
 function poetry() {
-    echo ">>> mocked poetry call <<<"
+    echo "       >>> mocked poetry call <<<"
 }
 
 export -f poetry

--- a/test/utils
+++ b/test/utils
@@ -60,7 +60,7 @@ function curl() {
 export -f curl
 
 function poetry() {
-    echo "       >>> mocked poetry call <<<"
+    echo ">>> mocked poetry call <<<"
 }
 
 export -f poetry


### PR DESCRIPTION
This PR uses code from:

- https://github.com/moneymeets/python-poetry-buildpack/pull/44

This should fix message in Heroku which states the installer cannot 
use the latest version of poetry. This PR uses the latest installer
which is recommended for use by the Poetry team:

- https://python-poetry.org/docs/#installing-with-the-official-installer

This branch has been tested on our DEV environment and the build completed successfully using poetry version v1.14.0.

![Screenshot 2022-09-01 at 10 21 23](https://user-images.githubusercontent.com/8884999/187884452-62cde64f-c3e8-44d2-b26c-6e801bc4215a.png)

